### PR TITLE
Disabled debug output Redis

### DIFF
--- a/lib/rack/insight/panels/redis_panel/stats.rb
+++ b/lib/rack/insight/panels/redis_panel/stats.rb
@@ -30,7 +30,7 @@ module Rack::Insight
 
       def record_call(time, command_args, method_call)
         @queries << Query.new(time, command_args, method_call)
-        puts "Recorded Redis Call: #{@queries.inspect}"
+        #puts "Recorded Redis Call: #{@queries.inspect}"
         @calls += 1
         @time += time
       end


### PR DESCRIPTION
На всех скриптах log/unicorn.stdout.log  завалены мусором.
